### PR TITLE
#5 - Implemented WhereKey to accept TArray<T> with primaryKey fields

### DIFF
--- a/Nowa.pas
+++ b/Nowa.pas
@@ -80,7 +80,7 @@ type
     function Update(const AModel: IModel<T>): ISQLCommand<T>;
     function Delete(const AModel: IModel<T>): ISQLCommand<T>;
     function Find(const AModel: IModel<T>; const AModelKey: T; const AKeyValue: Int64): ISQLCommand<T>;
-    function WhereKey(const AModel: IModel<T>; const AModelKey: T): ISQLCommand<T>;
+    function WhereKey(const AModel: IModel<T>; const AModelKey: TArray<T>): ISQLCommand<T>;
     function NewKeyValue(const ASequenceName: String): ISQLCommand<T>;
     function Exists(const AModel: IModel<T>; const AModelKey: T): ISQLCommand<T>;
   end;

--- a/NowaImpl.pas
+++ b/NowaImpl.pas
@@ -132,7 +132,7 @@ type
     function Insert(const AIModel: IModel<T>): ISQLCommand<T>;
     function Update(const AIModel: IModel<T>): ISQLCommand<T>;
     function Delete(const AIModel: IModel<T>): ISQLCommand<T>;
-    function WhereKey(const AIModel: IModel<T>; const AModelKey: T): ISQLCommand<T>;
+    function WhereKey(const AIModel: IModel<T>; const AModelKey: TArray<T>): ISQLCommand<T>;
     function NewKeyValue(const ASequenceName: String): ISQLCommand<T>;
     function Find(const AIModel: IModel<T>; const AModelKey: T; const AKeyValue: Int64): ISQLCommand<T>;
     function Exists(const AIModel: IModel<T>; const AModelKey: T): ISQLCommand<T>;
@@ -612,10 +612,23 @@ end;
 
 
 
-function TSQLCommand<T>.WhereKey(const AIModel: IModel<T>; const AModelKey: T): ISQLCommand<T>;
+function TSQLCommand<T>.WhereKey(const AIModel: IModel<T>; const AModelKey: TArray<T>): ISQLCommand<T>;
+var
+  oEFieldKey: T;
+  Condition: String;
 begin
   Result := Self;
-  sCommand := sCommand + ' where ' + LowerCase(AIModel.Field(AModelKey).Name) + ' = :' + AIModel.Field(AModelKey).Alias;
+  Condition := EmptyStr;
+
+  for oEFieldKey in AModelKey do
+  begin
+    if (not(Condition.IsEmpty)) then
+      Condition := Condition + ' and ';
+
+    Condition := Condition + LowerCase(AIModel.Field(oEFieldKey).Name) + ' = :' + AIModel.Field(oEFieldKey).Alias;
+  end;
+
+  sCommand := sCommand + ' where ' + Condition;
 end;
 
 

--- a/test/DAOExample/NowaDAO.pas
+++ b/test/DAOExample/NowaDAO.pas
@@ -11,7 +11,7 @@ type
   ['{EE817A67-A1E1-4A10-A80B-79902480A007}']
     procedure Insert(const AModel: IModel<T>);
     procedure Update(const AModel: IModel<T>);
-    procedure Save(const AModel: IModel<T>; const AModelKey: T);
+    procedure Save(const AModel: IModel<T>);
     procedure FillModel(const AModel: IModel<T>; const AQuery: TFDQuery);
   end;
 

--- a/test/DAOExample/NowaDAOImpl.pas
+++ b/test/DAOExample/NowaDAOImpl.pas
@@ -22,7 +22,7 @@ type
 
     procedure Insert(const AModel: IModel<T>);
     procedure Update(const AModel: IModel<T>);
-    procedure Save(const AModel: IModel<T>; const AModelKey: T);
+    procedure Save(const AModel: IModel<T>);
     procedure FillModel(const AModel: IModel<T>; const AQuery: TFDQuery);
   end;
 
@@ -79,18 +79,20 @@ end;
 
 
 
-procedure TNowaDAO<T>.Save(const AModel: IModel<T>; const AModelKey: T);
+procedure TNowaDAO<T>.Save(const AModel: IModel<T>);
 begin
   if AModel.IsNew then
   begin
     fCommand.CommandText.Text := TSQLCommand<T>.Create.Ref.Insert(AModel).Build;
-    AModel.SetValue(AModelKey, GenerateModelKey(AModel.Table.Sequence));
+
+    if (Length(AModel.PrimaryKey) = 1) then
+      AModel.SetValue(AModel.PrimaryKey[0], GenerateModelKey(AModel.Table.Sequence));
   end
   else
     fCommand.CommandText.Text :=
       TSQLCommand<T>.Create.Ref
         .Update(AModel)
-        .WhereKey(AModel, AModelKey)
+        .WhereKey(AModel, AModel.PrimaryKey)
         .Build;
 
   SaveModel(AModel);
@@ -113,8 +115,8 @@ end;
 
 
 procedure TNowaDAO<T>.Update(const AModel: IModel<T>);
-begin                                                                                    //TODO: Change it that pass TArray<T> of primary keys...
-  fCommand.CommandText.Text := TSQLCommand<T>.Create.Ref.Update(AModel).WhereKey(AModel, AModel.PrimaryKey[0]).Build;
+begin
+  fCommand.CommandText.Text := TSQLCommand<T>.Create.Ref.Update(AModel).WhereKey(AModel, AModel.PrimaryKey).Build;
   SaveModel(AModel);
 end;
 

--- a/test/NowaTest.pas
+++ b/test/NowaTest.pas
@@ -157,7 +157,7 @@ begin
   CheckEquals(sDelete,
     TSQLCommand<TEPerson>.Create.Ref
       .Delete(oIPerson)
-      .WhereKey(oIPerson, tepSequential)
+      .WhereKey(oIPerson, [tepSequential])
       .Build
   );
 end;
@@ -266,7 +266,7 @@ begin
   CheckEquals(sUpdate,
     TSQLCommand<TEPerson>.Create.Ref
       .Update(oIPerson)
-      .WhereKey(oIPerson, tepSequential)
+      .WhereKey(oIPerson, [tepSequential])
       .Build
   );
 end;


### PR DESCRIPTION
In NowaDAOImpl we can only generate primary key value if your model key is from one field, and not an compound key